### PR TITLE
Use a bool return type for traceme_stop_tracer().

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,15 +40,22 @@
 
 extern crate libc;
 
-use libc::{pid_t, c_char, c_void, getpid, size_t, c_int};
+use libc::{pid_t, c_char, c_void, getpid, size_t};
 use std::ffi::CString;
 use std::path::PathBuf;
+
+#[allow(dead_code)]
+#[repr(u8)]
+enum CBool {
+    CFalse = 0,
+    CTrue = 1,
+}
 
 // FFI stubs
 #[link(name = "traceme")]
 extern "C" {
     fn traceme_start_tracer(conf: *const TracerConf) -> *const c_void;
-    fn traceme_stop_tracer(tr_ctx: *const c_void) -> c_int;
+    fn traceme_stop_tracer(tr_ctx: *const c_void) -> u8;
 }
 
 // Struct used to communicate a tracing configuration to C. Must stay in sync with the C code.
@@ -184,7 +191,7 @@ impl Tracer {
             traceme_stop_tracer(self.tracer_ctx.expect("tracer wasn't started"))
         };
         if cfg!(not(travis)) {
-            assert!(rc == 0, "traceme_stop_tracer failed");
+            assert!(rc == CBool::CTrue as u8, "traceme_stop_tracer failed");
         }
     }
 }


### PR DESCRIPTION
This is my attempt to use a bool for the return type of one C function we missed.

I've tried to be careful about the conversion over the Rust/C boundary. The problem is, `bool` is of undefined size, meaning we don't know what to use to represent it on the Rust side.

I *thought* that by using a `u8` we are safe, but then I saw this comment:
https://github.com/rust-lang/rfcs/issues/1982#issuecomment-297531453

If a bool is 1-bit, then using a `u8` will read memory we don't own, argh. That said, this change does seem to work.

We don't have to merge this. We could use an `int` to be safe and the semantics are clear.

Any thoughts?

