### PR TITLE
Make the IPT tracer re-usable and document the mmap(2) dance.

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -51,6 +51,7 @@ pub enum HWTracerError {
     HardwareSupport(String),
     InvalidFileName(String),
     TracerAlreadyStarted,
+    TracerDestroyed,
     TracerNotStarted,
     TracingNotPermitted(String),
 }
@@ -91,6 +92,7 @@ impl Display for HWTracerError {
             HWTracerError::ElfError(ref m) => write!(f, "ELF error: {}", m),
             HWTracerError::InvalidFileName(ref n) => write!(f, "Invalid file name: `{}'", n),
             HWTracerError::TracerAlreadyStarted => write!(f, "Tracer already started"),
+            HWTracerError::TracerDestroyed => write!(f, "Tracer destroyed"),
             HWTracerError::TracerNotStarted => write!(f, "Tracer not started"),
             HWTracerError::TracingNotPermitted(ref m) => write!(f, "{}", m),
         }


### PR DESCRIPTION
This change makes the tracers efficiently re-usable.

Get some popcorn, because there's a bit of back-story before you can review.

In short, before we would `perf_event_open()` a new perf fd and `mmap()` our buffers every time we started tracing. This is inefficient as these can be re-used over and over. This change fixes that.

However, it comes with an API change which I didn't appreciate until implementing this. Before we had:
```
let tracer = PerfPTTracer::new().target_tid(12345).aux_bufsize(64);
tracer.start();
... work
let trace = tracer.stop()
```

Now that the tracer is re-usable, under this interface, the user might think they can re-configure the tracer before subsequent calls to `start_tracing()`:

```
let tracer = PerfPTTracer::new().target_tid(12345).aux_bufsize(64);
tracer.start();
... work
let trace1 = tracer.stop()

let tracer = tracer.target_tid(33333); // naughty! bad user!

tracer.start();
... work
let trace2 = tracer.stop()
```

This won't work because the file descriptor stored inside the `PerfPTTracer` is specific to a thread id (tid). AFAICS, the `perf_event_open()` API doesn't allow the tid to be changed after the fact. That's fine, and it actually fits nicely with our intention -- we don't want to share a these tracers between threads. We will have one per thread.

Although the buffer sizes *could* be changed on an existing tracer, I don't see any good reason to allow this, and it adds complexity.

My proposal is to have an API which "locks in" the configuration when the tracer instance is created:
```
let config = PerfPTTracer::config(); // gets the default config.
let config = config.target_tid(12345).aux_bufsize(64);
let tracer = PerfPTTracer::new(config); // config is now gone forever.
tracer.start();
... work
let trace1 = tracer.stop()

// There is nothing the user can do which might imply the configuration can be changed here.

tracer.start();
... work
let trace2 = tracer.stop()
```

Other notes:
 * On the Rust side, we can't use the existence of the opaque pointer to know if we are tracing or not, so I've added a Boolean flag.

 * On the C side, in order to split the initialisation from the starting of the tracer, I've had to understand the `mmap(2)` dance used to expose the kernel buffers. This code is fiddly and trips me up every time I look at it. To help my future self I've simplified the code a bit (and managed to eliminate a fair amount of sharing between threads) and added some comments. [In hindsight I would have liked to have that as a separate commit, but it will be hard to pick apart now, sorry.]

 * Checked `ptxed` can decode the trace when dumped to disk. All is well.

 * Tested under valgrind, and with error states too. All allocations freed, and fds closed.

 * All tests, including a new test pass.

 * Example amended to show repeated tracing.

Comments? OK?