### PR TITLE
Depend on libipt.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,9 @@ This library only supports Intel Processor Trace, but in the future we hope to
 support alternatives such as Arm's CoreSight.
 
 **This is experimental code.**
+
+## Notes
+
+When running `cargo`, you can set `IPT_PATH=...` to specify a path to a system
+libipt to use. If this variable is absent, Cargo will download and build libipt
+for you.

--- a/c_deps/.gitignore
+++ b/c_deps/.gitignore
@@ -1,0 +1,4 @@
+inst/
+mbuild/
+processor-trace/
+xed/

--- a/c_deps/Makefile
+++ b/c_deps/Makefile
@@ -1,0 +1,57 @@
+DIR != pwd
+INST_DIR = ${DIR}/inst
+PYTHON=python2.7
+
+PROCESSOR_TRACE_REPO = https://github.com/01org/processor-trace.git
+PROCESSOR_TRACE_V = 0ff8b29b2fd2ebfcc47a747862e948e8b638a020
+PROCESSOR_TRACE_SOURCE = processor-trace
+
+XED_REPO = https://github.com/intelxed/xed
+XED_V = bd73bdb2eefac1896b886e6a39e1794ae5267f7f
+XED_SOURCE = xed
+
+MBUILD_REPO = https://github.com/intelxed/mbuild
+MBUILD_V = bb9123152a330c7fa1ff1a502950dc199c83e177
+MBUILD_SOURCE = mbuild
+
+.PHONY: libipt
+
+all: libipt
+
+libipt: ${INST_DIR}/bin/ptdump
+
+${INST_DIR}:
+	install -d ${INST_DIR}/bin
+
+# Fetch targets
+${PROCESSOR_TRACE_SOURCE}:
+	git clone ${PROCESSOR_TRACE_REPO}
+	cd ${PROCESSOR_TRACE_SOURCE} && git checkout ${PROCESSOR_TRACE_V}
+
+${XED_SOURCE}:
+	git clone ${XED_REPO}
+	cd ${XED_SOURCE} && git checkout ${XED_V}
+
+${MBUILD_SOURCE}:
+	git clone ${MBUILD_REPO}
+	cd ${MBUILD_SOURCE} && git checkout ${MBUILD_V}
+
+# Build targets
+${PROCESSOR_TRACE_SOURCE}/bin/ptdump: ${PROCESSOR_TRACE_SOURCE} ${XED_SOURCE}/obj/libxed.so
+	cd ${PROCESSOR_TRACE_SOURCE} && \
+		env CFLAGS"=-I${DIR}/${XED_SOURCE}/include/public/xed -I${DIR}/${XED_SOURCE}/obj -Wno-error -g" \
+		LDFLAGS="-L${DIR}/${XED_SOURCE}/obj -Wl,-rpath=${DIR}/${XED_SOURCE}/obj" \
+		cmake -DCMAKE_INSTALL_PREFIX:PATH=${INST_DIR} \
+		-DPTDUMP=ON -DPTXED=ON -DSIDEBAND=ON -DFEATURE_ELF=ON -DDEVBUILD=ON . && ${MAKE}
+
+${XED_SOURCE}/obj/libxed.so: ${XED_SOURCE} ${MBUILD_SOURCE}
+	cd ${XED_SOURCE} && ${PYTHON} mfile.py --shared
+
+# Install targets
+${INST_DIR}/bin/ptdump: ${INST_DIR} ${PROCESSOR_TRACE_SOURCE}/bin/ptdump
+	cd ${PROCESSOR_TRACE_SOURCE} && ${MAKE} install
+	install ${PROCESSOR_TRACE_SOURCE}/bin/ptdump ${INST_DIR}/bin/
+	install ${PROCESSOR_TRACE_SOURCE}/bin/ptxed ${INST_DIR}/bin/
+
+clean:
+	rm -rf ${INST_DIR} ${PROCESSOR_TRACE_SOURCE} ${XED_SOURCE} ${MBUILD_SOURCE}

--- a/src/backends/perf_pt/decode.c
+++ b/src/backends/perf_pt/decode.c
@@ -1,0 +1,47 @@
+// Copyright (c) 2018 King's College London
+// created by the Software Development Team <http://soft-dev.org/>
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any
+// person obtaining a copy of this software, associated documentation and/or
+// data (collectively the "Software"), free of charge and under any and all
+// copyright rights in the Software, and any and all patent rights owned or
+// freely licensable by each licensor hereunder covering either (i) the
+// unmodified Software as contributed to or provided by such licensor, or (ii)
+// the Larger Works (as defined below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
+// if one is included with the Software (each a "Larger Work" to which the Software
+// is contributed by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create
+// derivative works of, display, perform, and distribute the Software and make,
+// use, sell, offer for sale, import, export, have made, and have sold the
+// Software and the Larger Work(s), and to sublicense the foregoing rights on
+// either these or other terms.
+//
+// This license is subject to the following condition: The above copyright
+// notice and either this complete permission notice or at a minimum a reference
+// to the UPL must be included in all copies or substantial portions of the
+// Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <intel-pt.h>
+
+void
+perf_pt_start_decode(void *buf) {
+    // XXX This function body is only here to check for correct libipt linkage
+    // at this time.
+    (void) buf;
+    struct pt_config config;
+    pt_blk_alloc_decoder(&config);
+}


### PR DESCRIPTION
This is the {fetch and build, use system} libipt build system change we discussed the other day.

No functional change. In preparation for decoding IPT traces. Dummy code is included to check linkage works.

Tested with/without bundled build of libipt.

Looks good?