### PR TITLE
Proper C Error Handling.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -131,6 +131,7 @@ fn main() {
         if feature_check("check_perf_pt.c") {
             c_build.file("src/backends/perf_pt/collect.c");
             c_build.file("src/backends/perf_pt/decode.c");
+            c_build.file("src/backends/perf_pt/util.c");
 
             // XXX At the time of writing you can't conditionally build C code for tests in a build
             // script: https://github.com/rust-lang/cargo/issues/1581

--- a/examples/simple_example.rs
+++ b/examples/simple_example.rs
@@ -70,7 +70,7 @@ fn print_trace(trace: &Box<Trace>, name: &str, result: u32, qty: usize) {
     let count = trace.iter_blocks().count();
     println!("{}: num_blocks={}, result={}", name, count, result);
 
-    for (i, blk) in trace.iter_blocks().take(qty) .enumerate() {
+    for (i, blk) in trace.iter_blocks().take(qty).enumerate() {
        println!("  block {}: 0x{:x}", i, blk.unwrap().start_vaddr());
     }
     if count > qty {

--- a/src/backends/perf_pt/test_helpers.c
+++ b/src/backends/perf_pt/test_helpers.c
@@ -114,7 +114,10 @@ append_self_ptxed_raw_args_cb(struct dl_phdr_info *info, size_t size, void *data
         uint64_t offset;
 
         if (vdso) {
-            if (!dump_vdso(args->vdso_fd, vaddr, phdr.p_memsz)) {
+            // Since this is testing code, we don't worry too much about the
+            // exact error, but we do have to pass down an error struct.
+            struct perf_pt_cerror err;
+            if (!dump_vdso(args->vdso_fd, vaddr, phdr.p_memsz, &err)) {
                 return 1;
             }
             filename = args->vdso_filename;

--- a/src/backends/perf_pt/util.c
+++ b/src/backends/perf_pt/util.c
@@ -35,41 +35,28 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-/*
- * This header contains items which are shared amongst multiple C files in the
- * perf_pt backend.
- */
-
-#ifndef __PERF_PT_PRIVATE_H
-#define __PERF_PT_PRIVATE_H
-
-#include <stddef.h>
-#include <inttypes.h>
 #include <stdbool.h>
+#include <intel-pt.h>
+#include "perf_pt_private.h"
 
-enum perf_pt_cerror_kind {
-    perf_pt_cerror_unused,
-    perf_pt_cerror_unknown,
-    perf_pt_cerror_errno,
-    perf_pt_cerror_ipt,
-};
+/*
+ * Sets the error information (if not already set).
+ */
+void
+perf_pt_set_err(struct perf_pt_cerror *err, int kind, int code) {
+    // Only set the error info if we would not be overwriting an earlier error.
+    if (err->kind == perf_pt_cerror_unused) {
+        err->kind = kind;
+        err->code = code;
+    }
+}
 
-struct perf_pt_cerror {
-    enum perf_pt_cerror_kind kind; // What sort of error is this?
-    int code;                      // The error code itself.
-};
-
-#define DEBUG(x...)                       \
-    do {                                  \
-        fprintf(stderr, "%s:%d [%s]: ",   \
-           __FILE__, __LINE__, __func__); \
-        fprintf(stderr, x);               \
-        fprintf(stderr, "\n");            \
-    } while (0)
-
-bool dump_vdso(int, uint64_t, size_t, struct perf_pt_cerror *);
-void perf_pt_set_err(struct perf_pt_cerror *, int, int);
-
-#define VDSO_NAME "linux-vdso.so.1"
-
-#endif
+/*
+ * Indicates if the specified error code is the overflow code.
+ * This exists to avoid copying (and keeping in sync) the ipt error code on the
+ * Rust side.
+ */
+bool
+perf_pt_is_overflow_err(int err) {
+    return err == pte_overflow;
+}


### PR DESCRIPTION
This implements a error handling scheme for the perf_pt backend which is capable of communicating libipt and errno style errors.

Instead of just returning "something went wrong", we now set a type and code using `perf_pt_set_err`, which Rust then converts into a high-level error type.

It took a little longer than expected due to some fiddly cases.

Notes:

 * First commit is an unrelated OCD fix.
 * The overflow case is now properly handled, rather than being munged together with all other errors. So now we can know when to retry.
 * Removed an error indicator from a function which cannot fail  (`read_aux()`).
 * Fixed a NULL pointer dereference (I'll point this out).
 * Added a field into the tracer context to store errors that can occur inside the thread. It needs to live here so that the error struct can live for the entirety of the tracing session. Then in `stop_tracing` we check if anything went wrong "while we were away".

I did wonder if I need to add a comment to every function accepting an error struct. What do you think? Overkill?

Thanks

Fixes #56 