### PR TITLE
Fix error reporting, deal with block Iterator invalidation on error.

### DIFF
--- a/src/backends/perf_pt/mod.rs
+++ b/src/backends/perf_pt/mod.rs
@@ -100,7 +100,7 @@ impl PerfPTCError {
     // Creates a new error struct defaulting to an unknown error.
     fn new() -> Self {
         Self {
-            typ: PerfPTCErrorKind::Unknown,
+            typ: PerfPTCErrorKind::Unused,
             code: 0,
         }
     }


### PR DESCRIPTION
Hi,

I think this is the correct fix for #55. Also initialise error structs to `unused` not `unknown` (oops).