### PR TITLE
Alllow the user to configure when to empty the AUX ringbuffer.

### DIFF
--- a/src/backends/perf_pt/mod.rs
+++ b/src/backends/perf_pt/mod.rs
@@ -856,6 +856,7 @@ mod tests {
             },
             _ => panic!(),
         }
+        PerfPTTracer::new(PerfPTTracer::config().data_bufsize(2048)).unwrap().destroy().unwrap();
     }
 
     #[test]
@@ -866,6 +867,7 @@ mod tests {
             },
             _ => panic!(),
         }
+        PerfPTTracer::new(PerfPTTracer::config().aux_bufsize(2048)).unwrap().destroy().unwrap();
     }
 
     #[test]


### PR DESCRIPTION
I think it would be a good idea to expose this to the user as a configuration variable.

See individual commits.

Thanks