### PR TITLE
Add a missing struct field on the C side.

### DIFF
--- a/src/backends/perf_pt/collect.c
+++ b/src/backends/perf_pt/collect.c
@@ -99,6 +99,8 @@ struct tracer_conf {
     pid_t       target_tid;         // Thread ID to trace.
     size_t      data_bufsize;       // Data buf size (in pages).
     size_t      aux_bufsize;        // AUX buf size (in pages).
+    size_t      new_trace_bufsize;  // Initial capacity (in bytes) of a
+                                    // trace storage buffer.
 };
 
 /*


### PR DESCRIPTION
This struct is out of sync with the Rust side.

Although we never use it by value, we should avoid any surprises by bringing it into sync.

Here's the Rust equivalent:
https://github.com/softdevteam/hwtracer/blob/cc3b2229cae51118163a81c7aeb2c7641f146075/src/backends/perf_pt/mod.rs#L313-L326