### PR TITLE
Kill the explicit destroy in the Tracer API.

### DIFF
--- a/examples/simple_example.rs
+++ b/examples/simple_example.rs
@@ -106,7 +106,4 @@ fn main() {
         let name = format!("trace{}", i);
         print_trace(&trace, &name, res, 10);
     }
-
-    // Tracers require manual clean up (since clean up could fail).
-    tracer.destroy().unwrap();
 }


### PR DESCRIPTION
As discussed on mattermost, this was once needed, but no more. As you can see the `destroy` methods don't really do any clean up at all.

OK?