### PR TITLE
Build fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Edd Barrett <vext01@gmail.com>"]
 libc = "0.2"
 lazy_static = "1.1"
 time = "0.1"
-tempfile = "2.2.0"
+tempfile = "3.0"
 
 [build-dependencies]
 cc = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ time = "0.1"
 tempfile = "2.2.0"
 
 [build-dependencies]
-gcc = "0.3.54"
+cc = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 authors = ["Edd Barrett <vext01@gmail.com>"]
 
 [dependencies]
-libc = "0.2.33"
-lazy_static = "1.0"
+libc = "0.2"
+lazy_static = "1.1"
 time = "0.1"
 tempfile = "2.2.0"
 

--- a/build.rs
+++ b/build.rs
@@ -39,12 +39,10 @@
 
 extern crate gcc;
 
-#[cfg(target_os = "linux")]
 use std::path::{PathBuf, Path};
 use std::env;
 use std::process::Command;
 
-#[cfg(target_os = "linux")]
 const FEATURE_CHECKS_PATH: &str = "feature_checks";
 
 const C_DEPS_DIR: &str = "c_deps";
@@ -52,7 +50,6 @@ const C_DEPS_DIR: &str = "c_deps";
 /// Simple feature check, returning `true` if we have the feature.
 ///
 /// The checks themselves are in files under `FEATURE_CHECKS_PATH`.
-#[cfg(target_os = "linux")]
 fn feature_check(filename: &str) -> bool {
     let mut path = PathBuf::new();
     path.push(FEATURE_CHECKS_PATH);

--- a/build.rs
+++ b/build.rs
@@ -37,7 +37,7 @@
 
 #![feature(asm)]
 
-extern crate gcc;
+extern crate cc;
 
 use std::path::{PathBuf, Path};
 use std::env;
@@ -55,7 +55,7 @@ fn feature_check(filename: &str) -> bool {
     path.push(FEATURE_CHECKS_PATH);
     path.push(filename);
 
-    let mut check_build = gcc::Build::new();
+    let mut check_build = cc::Build::new();
     check_build.file(path).try_compile("check_perf_pt").is_ok()
 }
 
@@ -121,7 +121,7 @@ fn cpu_supports_pt() -> bool {
 }
 
 fn main() {
-    let mut c_build = gcc::Build::new();
+    let mut c_build = cc::Build::new();
 
     // We need the C_DEPS_DIR to be absolute so that our consumers inherit correct linker paths.
     let mut c_deps_path_abs = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());


### PR DESCRIPTION
This PR makes things build on OpenBSD and updates several dependencies. Mostly these are easy but two (gcc -> cc; and tempfile 2.* to 3.*) require minor code changes.

This passes all tests on bencher8 (except `backends::perf_pt::tests::test_block_iterator5` which it skips, presumably intentionally?).