### PR TITLE
Rename start_vaddr and len

### DIFF
--- a/examples/simple_example.rs
+++ b/examples/simple_example.rs
@@ -12,7 +12,7 @@ fn print_trace(trace: &Box<dyn Trace>, name: &str, result: u32, qty: usize) {
     println!("{}: num_blocks={}, result={}", name, count, result);
 
     for (i, blk) in trace.iter_blocks().take(qty).enumerate() {
-       println!("  block {}: 0x{:x}", i, blk.unwrap().start_vaddr());
+       println!("  block {}: 0x{:x}", i, blk.unwrap().first_instr());
     }
     if count > qty {
         println!("  ... {} more", count - qty);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,21 +22,26 @@ use std::fs::File;
 /// Information about a basic block.
 #[derive(Debug, Eq, PartialEq)]
 pub struct Block {
-    start_vaddr: u64,
-    len: u64,
+    /// Virtual address of the first instruction in this block.
+    first_instr: u64,
+    /// Virtual address of the last instruction in this block.
+    last_instr: u64,
 }
 
 impl Block {
-    pub fn new(start_vaddr: u64, len: u64) -> Self {
-        Self {start_vaddr, len}
+    /// Creates a new basic block from a start address and a length in bytes.
+    pub fn new(first_instr: u64, last_instr: u64) -> Self {
+        Self {first_instr, last_instr}
     }
 
-    pub fn start_vaddr(&self) -> u64 {
-        self.start_vaddr
+    /// Returns the virtual address of the first instruction in this block.
+    pub fn first_instr(&self) -> u64 {
+        self.first_instr
     }
 
-    pub fn len(&self) -> u64 {
-        self.len
+    /// Returns the virtual address of the last instruction in this block.
+    pub fn last_instr(&self) -> u64 {
+        self.last_instr
     }
 }
 
@@ -168,7 +173,7 @@ mod test_helpers {
             if expect.is_none() || got.is_none() {
                 break;
             }
-            assert_eq!(got.unwrap().unwrap().start_vaddr(), expect.unwrap().start_vaddr());
+            assert_eq!(got.unwrap().unwrap().first_instr(), expect.unwrap().first_instr());
         }
         // Check that both iterators were the same length.
         assert!(expect_iter.next().is_none());


### PR DESCRIPTION
This will break our yk repo, so I'll have to raise a "companion" PR with this to fix that. However, there's currently some other stuff going on on the yk repo, so let's wait until that's finished. However, we can start the review in the meantime.

The current name for these variables suggests that they give the range
of the block, which would allow to calculate the next block by adding
together `start_vaddr` and `len`. This is not the case though, since len
is calculated from `block.end_ip` which returns the address of the last
instruction in this block. This means that a block with a single
instruction would have a `len` of 0, which is unintuitive.

This commit renames the variables to `first_instr` and `last_instr` and
changes the latter to return the addresses of the last instruction of
the block (instead of returning its length).