### PR TITLE
Fix compilation error in tests.

### DIFF
--- a/src/backends/perf_pt/mod.rs
+++ b/src/backends/perf_pt/mod.rs
@@ -521,7 +521,7 @@ mod tests {
             };
 
             for hdr in obj.iter_phdrs() {
-                if hdr.type_() != PT_LOAD || hdr.flags() & PF_X == 0 {
+                if hdr.type_() != PT_LOAD || hdr.flags() & PF_X.0 == 0 {
                     continue; // Only look at loadable and executable segments.
                 }
 


### PR DESCRIPTION
Another compilation error that somehow slipped CI. I don't get it...

Did we perhaps manually merge in a time where CI was down?