### PR TITLE
Remove #![feature(optin_builtin_traits)].

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
-#![feature(optin_builtin_traits)]
 #![feature(link_args)]
 
 pub mod backends;


### PR DESCRIPTION
It's no longer needed and its presence breaks hwtracer on bleeding edge rustc/ykrustc.