### PR TITLE
Stop tracing upon drop.

### DIFF
--- a/src/backends/perf_pt/mod.rs
+++ b/src/backends/perf_pt/mod.rs
@@ -403,6 +403,15 @@ impl Default for PerfPTThreadTracer {
     }
 }
 
+impl Drop for PerfPTThreadTracer {
+    fn drop(&mut self) {
+        if self.state == TracerState::Started {
+            // If we haven't stopped the tracer already, stop it now.
+            self.stop_tracing().unwrap();
+        }
+    }
+}
+
 impl ThreadTracer for PerfPTThreadTracer {
     fn start_tracing(&mut self) -> Result<(), HWTracerError> {
         if self.state == TracerState::Started {


### PR DESCRIPTION
It's possible for PerfPTThreadTracer to be dropped while it is still
tracing, leaving the PT tracer running. This can cause issues with other
threads wanting to trace. Calling stop_tracing on the PT tracer when the
hardware tracer is dropped fixes this.