### PR TITLE
Kill ipt hack

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -52,7 +52,6 @@ fn build_libipt(c_deps_dir: &Path) {
     let res = Command::new("make")
         .arg("-f")
         .arg(C_DEPS_MAKEFILE)
-        .arg("libipt")
         .output()
         .unwrap_or_else(|_| panic!("Fatal error when building libipt"));
     if !res.status.success() {
@@ -74,7 +73,7 @@ fn fetch_libipt(c_deps_dir: &Path) {
     let prev_dir = env::current_dir().unwrap();
     env::set_current_dir(c_deps_dir).unwrap();
     let res = Command::new("make")
-        .arg("processor-trace") // target just fetches the code.
+        .arg("libipt") // target just fetches the code.
         .output()
         .unwrap_or_else(|_| panic!("Fatal error when fetching libipt"));
     if !res.status.success() {
@@ -128,16 +127,10 @@ fn main() {
         // If we built our own libipt above, then the fetch is a no-op.
         fetch_libipt(&c_deps_dir);
 
-        c_build.include(&format!(
-            "{}/processor-trace/libipt/internal/include",
-            c_deps_dir_s
-        ));
+        c_build.include(&format!("{}/libipt/libipt/internal/include", c_deps_dir_s));
+        c_build.file(&format!("{}/libipt/libipt/src/pt_cpu.c", c_deps_dir_s));
         c_build.file(&format!(
-            "{}/processor-trace/libipt/src/pt_cpu.c",
-            c_deps_dir_s
-        ));
-        c_build.file(&format!(
-            "{}/processor-trace/libipt/src/posix/pt_cpuid.c",
+            "{}/libipt/libipt/src/posix/pt_cpuid.c",
             c_deps_dir_s
         ));
 

--- a/c_deps.mk
+++ b/c_deps.mk
@@ -5,23 +5,21 @@ DIR != pwd
 INST_DIR = ${DIR}/inst
 PYTHON=python3
 
-PROCESSOR_TRACE_REPO = https://github.com/01org/processor-trace.git
+PROCESSOR_TRACE_REPO = https://github.com/intel/libipt
 PROCESSOR_TRACE_V = ffe1631be3dad2dc286529e3e05d552043d626f0
-PROCESSOR_TRACE_SOURCE = processor-trace
+PROCESSOR_TRACE_SOURCE = libipt
 
 XED_REPO = https://github.com/intelxed/xed
-XED_V = afbb851b5f2f2ac6cdb6e6d9bebbaf2d4e77286d
+XED_V = f7191e268c3ee17fc8c9b8d9bd3eee7159f29556
 XED_SOURCE = xed
 
 MBUILD_REPO = https://github.com/intelxed/mbuild
-MBUILD_V = 5304b94361fccd830c0e2417535a866b79c1c297
+MBUILD_V = 3e8eb33aada4153c21c4261b35e5f51f6e2019e8
 MBUILD_SOURCE = mbuild
 
 .PHONY: libipt
 
-all: libipt
-
-libipt: ${INST_DIR}/bin/ptdump
+all: ${INST_DIR}/bin/ptdump
 
 ${INST_DIR}:
 	install -d ${INST_DIR}/bin

--- a/c_deps.mk
+++ b/c_deps.mk
@@ -6,7 +6,7 @@ INST_DIR = ${DIR}/inst
 PYTHON=python3
 
 PROCESSOR_TRACE_REPO = https://github.com/01org/processor-trace.git
-PROCESSOR_TRACE_V = 890e5406a37621f851846b99fc381753b57463d1
+PROCESSOR_TRACE_V = ffe1631be3dad2dc286529e3e05d552043d626f0
 PROCESSOR_TRACE_SOURCE = processor-trace
 
 XED_REPO = https://github.com/intelxed/xed

--- a/src/backends/perf_pt/decode.c
+++ b/src/backends/perf_pt/decode.c
@@ -375,9 +375,7 @@ block_is_terminated(struct pt_block *blk)
         case ptic_ptwrite:
             ret = false;
             break;
-        case ptic_error:
-            // This is not correct, but is blocked on:
-            // https://github.com/intel/libipt/issues/73
+        case ptic_indirect:
             ret = true;
             break;
         default:


### PR DESCRIPTION
Upstream libipt merged a branch that was blocking the fixing of a workaround, so we can now pull that in and remove the workaround.

While we are here, update all of the C dependencies, and libipt moved on github too, so use the new URL.

Tested the `yk` repo. All is well.