### PR TITLE
Make hwtracer build with the latest Rust nightly.

### DIFF
--- a/examples/simple_example.rs
+++ b/examples/simple_example.rs
@@ -39,7 +39,7 @@ fn main() {
 
     for i in 1..4 {
         thr_tracer.start_tracing().unwrap_or_else(|e| {
-            panic!(format!("Failed to start tracer: {}", e));
+            panic!("Failed to start tracer: {}", e);
         });
         let res = work();
         let trace = thr_tracer.stop_tracing().unwrap();

--- a/src/backends/perf_pt/mod.rs
+++ b/src/backends/perf_pt/mod.rs
@@ -88,14 +88,6 @@ impl From<PerfPTCError> for HWTracerError {
 }
 
 // FFI prototypes.
-//
-// XXX Rust bug. link_args always reported unused.
-// https://github.com/rust-lang/rust/issues/29596#issuecomment-310288094
-//
-// XXX Cargo bug(?).
-// Linker flags in build.rs ignored for the testing target. We must use `link_args` instead.
-#[allow(unused_attributes)]
-#[link_args = "-lipt"]
 extern "C" {
     // collect.c
     fn perf_pt_init_tracer(conf: *const PerfPTConfig, err: *mut PerfPTCError) -> *mut c_void;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
-#![feature(link_args)]
 
 pub mod backends;
 pub mod errors;


### PR DESCRIPTION
Namely:
 - `#[link_args]` has been removed from Rust and it's no longer needed.
 - `panic!(format!(..))` is an error in the latest Rust.